### PR TITLE
Cancel timer when it's not needed to avoid memory leak

### DIFF
--- a/lib/views/clock_page.dart
+++ b/lib/views/clock_page.dart
@@ -117,9 +117,11 @@ class DigitalClockWidget extends StatefulWidget {
 
 class DigitalClockWidgetState extends State<DigitalClockWidget> {
   var formattedTime = DateFormat('HH:mm').format(DateTime.now());
+  Timer timer;
+
   @override
   void initState() {
-    Timer.periodic(Duration(seconds: 1), (timer) {
+    this.timer = Timer.periodic(Duration(seconds: 1), (timer) {
       var perviousMinute = DateTime.now().add(Duration(seconds: -1)).minute;
       var currentMinute = DateTime.now().minute;
       if (perviousMinute != currentMinute)
@@ -128,6 +130,12 @@ class DigitalClockWidgetState extends State<DigitalClockWidget> {
         });
     });
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    this.timer.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/views/clockview.dart
+++ b/lib/views/clockview.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+
 import 'package:clock_app/constants/theme_data.dart';
 import 'package:flutter/material.dart';
 
@@ -13,12 +14,20 @@ class ClockView extends StatefulWidget {
 }
 
 class _ClockViewState extends State<ClockView> {
+  Timer timer;
+
   @override
   void initState() {
-    Timer.periodic(Duration(seconds: 1), (timer) {
+    this.timer = Timer.periodic(Duration(seconds: 1), (timer) {
       setState(() {});
     });
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    this.timer.cancel();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
This commit fix this error:

```
E/flutter (20913): [ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: setState() called after dispose(): _ClockViewState#24b51(lifecycle state: defunct, not mounted)
E/flutter (20913): This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
E/flutter (20913): The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
E/flutter (20913): This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
E/flutter (20913): #0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1208:9)
E/flutter (20913): #1      State.setState (package:flutter/src/widgets/framework.dart:1243:6)
E/flutter (20913): #2      _ClockViewState.initState.<anonymous closure> (package:clock_app/views/clockview.dart:19:7)
E/flutter (20913): #3      _rootRunUnary (dart:async/zone.dart:1198:47)
E/flutter (20913): #4      _CustomZone.runUnary (dart:async/zone.dart:1100:19)
E/flutter (20913): #5      _CustomZone.runUnaryGuarded (dart:async/zone.dart:1005:7)
E/flutter (20913): #6      _CustomZone.bindUnaryCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1042:26)
E/flutter (20913): #7      _rootRunUnary (dart:async/zone.dart:1206:13)
E/flutter (20913): #8      _CustomZone.runUnary (dart:async/zone.dart:1100:19)
E/flutter (20913): #9      _CustomZone.bindUnaryCallback.<anonymous closure> (dart:async/zone.dart:1026:26)
E/flutter (20913): #10     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:397:19)
E/flutter (20913): #11     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:428:5)
E/flutter (20913): #12     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
E/flutter (20913):
```